### PR TITLE
Adds --ignore-training-axistags ilastik run

### DIFF
--- a/hpc/remote_scripts/run_ilastik.sh
+++ b/hpc/remote_scripts/run_ilastik.sh
@@ -30,6 +30,7 @@ srun ilastik.py \
     --export_source="${ILASTIK_EXPORT_SOURCE}" \
     --output_filename_format "$OUT_FILE_NAME" \
     --raw_data "${ILASTIK_RAW_DATA}" \
+    --ignore-training-axistags \
     ${ILASTIK_EXTRA_OPTIONS}
 
 srun --ntasks 1 swift upload "$OUTPUT_BUCKET_NAME" "$OUT_FILE_NAME"


### PR DESCRIPTION
When using the web training, it's possible that the training axistags might
not match those of the data when running in headless mode, since the
training might happen on precomputed chunks, for example, and the headless
run might happen on local .n5 files. This commit makes ilastik check
the dataset itself for the axis tags rather than trusting the training data